### PR TITLE
Fix doc lookup paths and bundle scraped docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "build",
+    "scraped_docs",
     "README.md",
     "LICENSE"
   ],

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -77,7 +77,7 @@ function getPriority(category: string): number {
 export const resources = {
   list(): Resource[] {
     try {
-      const docsPath = join(__dirname, "../../../scraped_docs");
+      const docsPath = join(__dirname, "../../scraped_docs");
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));
       
       const resourceList: Resource[] = [];
@@ -133,7 +133,7 @@ export const resources = {
         throw new Error(`Invalid filename: ${filename}`);
       }
       
-      const docsPath = join(__dirname, "../../../scraped_docs");
+      const docsPath = join(__dirname, "../../scraped_docs");
       const filePath = join(docsPath, filename);
       
       // Check if file exists

--- a/src/tools/getDocsByCategory.ts
+++ b/src/tools/getDocsByCategory.ts
@@ -102,7 +102,7 @@ export const getDocsByCategory = {
     const { category } = args;
     
     try {
-      const docsPath = join(__dirname, "../../../scraped_docs");
+      const docsPath = join(__dirname, "../../scraped_docs");
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));
       
       if (category === "overview") {

--- a/src/tools/searchDocs.ts
+++ b/src/tools/searchDocs.ts
@@ -139,7 +139,7 @@ export const searchDocs = {
     
     try {
       // Get path to scraped_docs directory
-      const docsPath = join(__dirname, "../../../scraped_docs");
+      const docsPath = join(__dirname, "../../scraped_docs");
       
       // Read all markdown files
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));


### PR DESCRIPTION
## Summary
- fix all documentation lookups to resolve the scraped_docs directory relative to the package root
- include scraped_docs in the published files so npm installs ship the documentation bundle

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2bd991c08325895e6e29c0d57aa9