### PR TITLE
Handle Smithery build without import.meta

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,28 @@ import { searchDocs } from "./tools/searchDocs.js";
 import { getDocsByCategory } from "./tools/getDocsByCategory.js";
 import { prompts } from "./prompts/index.js";
 import { resources } from "./resources/index.js";
+import { moduleFileFromUrl, pathsAreEqual } from "./utils/modulePaths.js";
+
+function getImportMetaUrl(): string | undefined {
+  try {
+    return (import.meta as ImportMeta).url;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+const moduleMetaUrl = getImportMetaUrl();
+
+function isExecutedDirectly(metaUrl?: string): boolean {
+  if (typeof module !== "undefined" && module?.parent === null) {
+    return true;
+  }
+
+  const moduleFile = moduleFileFromUrl(metaUrl);
+  const entryFile = Array.isArray(process.argv) ? process.argv[1] : undefined;
+
+  return pathsAreEqual(moduleFile, entryFile);
+}
 
 const server = new Server(
   {
@@ -224,7 +246,7 @@ async function main() {
   console.error("MCP Docs Server running on stdio");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isExecutedDirectly(moduleMetaUrl)) {
   main().catch((error) => {
     console.error("Server failed:", error);
     process.exit(1);

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,9 +1,18 @@
 import { readFileSync, readdirSync, statSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { docsDirFrom, moduleDirFromUrl } from "../utils/modulePaths.js";
+
+function getImportMetaUrl(): string | undefined {
+  try {
+    return (import.meta as ImportMeta).url;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+const moduleDir = moduleDirFromUrl(getImportMetaUrl());
+const docsDirectory = docsDirFrom(moduleDir);
 
 interface Resource {
   uri: string;
@@ -77,7 +86,7 @@ function getPriority(category: string): number {
 export const resources = {
   list(): Resource[] {
     try {
-      const docsPath = join(__dirname, "../../scraped_docs");
+      const docsPath = docsDirectory;
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));
       
       const resourceList: Resource[] = [];
@@ -133,7 +142,7 @@ export const resources = {
         throw new Error(`Invalid filename: ${filename}`);
       }
       
-      const docsPath = join(__dirname, "../../scraped_docs");
+      const docsPath = docsDirectory;
       const filePath = join(docsPath, filename);
       
       // Check if file exists

--- a/src/tools/getDocsByCategory.ts
+++ b/src/tools/getDocsByCategory.ts
@@ -1,10 +1,19 @@
 import { z } from "zod";
 import { readFileSync, readdirSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { docsDirFrom, moduleDirFromUrl } from "../utils/modulePaths.js";
+
+function getImportMetaUrl(): string | undefined {
+  try {
+    return (import.meta as ImportMeta).url;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+const moduleDir = moduleDirFromUrl(getImportMetaUrl());
+const docsDirectory = docsDirFrom(moduleDir);
 
 const inputSchema = z.object({
   category: z.enum([
@@ -102,7 +111,7 @@ export const getDocsByCategory = {
     const { category } = args;
     
     try {
-      const docsPath = join(__dirname, "../../scraped_docs");
+      const docsPath = docsDirectory;
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));
       
       if (category === "overview") {

--- a/src/tools/searchDocs.ts
+++ b/src/tools/searchDocs.ts
@@ -1,10 +1,19 @@
 import { z } from "zod";
 import { readFileSync, readdirSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { docsDirFrom, moduleDirFromUrl } from "../utils/modulePaths.js";
+
+function getImportMetaUrl(): string | undefined {
+  try {
+    return (import.meta as ImportMeta).url;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+const moduleDir = moduleDirFromUrl(getImportMetaUrl());
+const docsDirectory = docsDirFrom(moduleDir);
 
 const inputSchema = z.object({
   query: z.string().describe("Search query - keywords, phrases, or specific concepts to find in the documentation"),
@@ -139,7 +148,7 @@ export const searchDocs = {
     
     try {
       // Get path to scraped_docs directory
-      const docsPath = join(__dirname, "../../scraped_docs");
+      const docsPath = docsDirectory;
       
       // Read all markdown files
       const files = readdirSync(docsPath).filter(file => file.endsWith('.md'));

--- a/src/utils/modulePaths.ts
+++ b/src/utils/modulePaths.ts
@@ -1,0 +1,69 @@
+import { existsSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+export function moduleDirFromUrl(importMetaUrl?: string): string {
+  if (importMetaUrl) {
+    try {
+      return dirname(fileURLToPath(importMetaUrl));
+    } catch (error) {
+      // If the URL can't be converted, fall back to process-based heuristics
+    }
+  }
+
+  if (typeof process !== "undefined" && Array.isArray(process.argv) && process.argv[1]) {
+    return dirname(process.argv[1]);
+  }
+
+  return process.cwd();
+}
+
+export function moduleFileFromUrl(importMetaUrl?: string): string | undefined {
+  if (importMetaUrl) {
+    try {
+      return fileURLToPath(importMetaUrl);
+    } catch (error) {
+      // Ignore conversion errors and try other strategies below
+    }
+  }
+
+  if (typeof process !== "undefined" && Array.isArray(process.argv) && process.argv[1]) {
+    return process.argv[1];
+  }
+
+  return undefined;
+}
+
+export function projectRootFrom(startDir: string): string {
+  let currentDir = startDir;
+  const visited = new Set<string>();
+
+  while (!visited.has(currentDir)) {
+    visited.add(currentDir);
+
+    if (existsSync(join(currentDir, "scraped_docs"))) {
+      return currentDir;
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+
+    currentDir = parentDir;
+  }
+
+  return startDir;
+}
+
+export function docsDirFrom(startDir: string): string {
+  return join(projectRootFrom(startDir), "scraped_docs");
+}
+
+export function pathsAreEqual(a?: string, b?: string): boolean {
+  if (!a || !b) {
+    return false;
+  }
+
+  return resolve(a) === resolve(b);
+}


### PR DESCRIPTION
## Summary
- add module path utilities to resolve module and documentation directories without relying on import.meta so Smithery's CJS bundle can locate resources
- update the server entrypoint, resource reader, and documentation tools to use the helpers and safely detect direct execution under both ESM and CJS builds

## Testing
- npm run build
- npx -y @smithery/cli@1.2.31 build -o .smithery/index.cjs
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd4c5c5b988325952630cfee1d3e5b