### PR TITLE
Add default server factory export for Smithery compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { 
+import {
   CallToolRequestSchema,
   ErrorCode,
   ListToolsRequestSchema,
@@ -42,205 +42,251 @@ function isExecutedDirectly(metaUrl?: string): boolean {
   return pathsAreEqual(moduleFile, entryFile);
 }
 
-const server = new Server(
-  {
+interface ServerMetadata {
+  name: string;
+  version: string;
+}
+
+export interface CreateServerParams {
+  sessionId?: string;
+  config?: unknown;
+}
+
+function resolveServerMetadata(config: unknown): ServerMetadata {
+  const metadata: ServerMetadata = {
     name: "mcp-docs-server",
     version: "1.0.0",
-  },
-  {
-    capabilities: {
-      tools: {},
-      prompts: {},
-      resources: {},
+  };
+
+  if (config && typeof config === "object") {
+    const configRecord = config as Record<string, unknown>;
+    const name = configRecord["name"];
+    const version = configRecord["version"];
+
+    if (typeof name === "string" && name.trim().length > 0) {
+      metadata.name = name;
+    }
+
+    if (typeof version === "string" && version.trim().length > 0) {
+      metadata.version = version;
+    }
+  }
+
+  return metadata;
+}
+
+export function createServer(params: CreateServerParams = {}): Server {
+  const metadata = resolveServerMetadata(params.config);
+
+  const server = new Server(
+    {
+      name: metadata.name,
+      version: metadata.version,
     },
-  }
-);
-
-// List available tools
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "mcp_docs_guide",
-        description: "Get comprehensive guides and documentation for Model Context Protocol development. Covers getting started, building servers/clients, core concepts, and best practices.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            topic: {
-              type: "string",
-              enum: [
-                "getting_started",
-                "building_servers", 
-                "building_clients",
-                "core_concepts",
-                "tools_and_resources",
-                "protocol_specification",
-                "troubleshooting",
-                "best_practices",
-                "examples_and_tutorials"
-              ],
-              description: "The documentation topic you'd like guidance on"
-            }
-          },
-          required: ["topic"]
-        }
+    {
+      capabilities: {
+        tools: {},
+        prompts: {},
+        resources: {},
       },
-      {
-        name: "search_docs",
-        description: "Search through MCP documentation using keywords or phrases. Returns relevant documentation sections with context.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description: "Search query - keywords, phrases, or specific concepts to find in the documentation"
-            },
-            category: {
-              type: "string",
-              enum: [
-                "all",
-                "getting_started", 
-                "concepts",
-                "development",
-                "specification",
-                "tools",
-                "community"
-              ],
-              description: "Optional: limit search to specific documentation category",
-              default: "all"
-            }
-          },
-          required: ["query"]
-        }
-      },
-      {
-        name: "get_docs_by_category",
-        description: "Get documentation organized by category. Returns structured overview of available documentation in each area.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            category: {
-              type: "string",
-              enum: [
-                "overview",
-                "getting_started",
-                "concepts", 
-                "development",
-                "specification",
-                "tools",
-                "community"
-              ],
-              description: "The documentation category to explore"
-            }
-          },
-          required: ["category"]
-        }
-      }
-    ],
-  };
-});
-
-// Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  try {
-    switch (name) {
-      case "mcp_docs_guide":
-        return await mcpDocsGuide.execute(args as any);
-
-      case "search_docs":
-        return await searchDocs.execute(args as any);
-
-      case "get_docs_by_category":
-        return await getDocsByCategory.execute(args as any);
-
-      default:
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          `Unknown tool: ${name}`
-        );
     }
-  } catch (error) {
-    if (error instanceof McpError) {
-      throw error;
-    }
-    throw new McpError(
-      ErrorCode.InternalError,
-      `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
-});
+  );
 
-// List available prompts
-server.setRequestHandler(ListPromptsRequestSchema, async () => {
-  return {
-    prompts: Object.values(prompts).map((prompt: any) => ({
-      name: prompt.name,
-      description: prompt.description,
-      arguments: prompt.arguments || []
-    }))
-  };
-});
-
-// Handle prompt requests
-server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  
-  const prompt = (prompts as any)[name];
-  if (!prompt) {
-    throw new McpError(
-      ErrorCode.InvalidRequest,
-      `Unknown prompt: ${name}`
-    );
-  }
-
-  try {
-    const result = await prompt.handler(args || {});
+  // List available tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      messages: [
+      tools: [
         {
-          role: "user" as const,
-          content: {
-            type: "text" as const,
-            text: result
-          }
-        }
-      ]
+          name: "mcp_docs_guide",
+          description:
+            "Get comprehensive guides and documentation for Model Context Protocol development. Covers getting started, building servers/clients, core concepts, and best practices.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              topic: {
+                type: "string",
+                enum: [
+                  "getting_started",
+                  "building_servers",
+                  "building_clients",
+                  "core_concepts",
+                  "tools_and_resources",
+                  "protocol_specification",
+                  "troubleshooting",
+                  "best_practices",
+                  "examples_and_tutorials",
+                ],
+                description: "The documentation topic you'd like guidance on",
+              },
+            },
+            required: ["topic"],
+          },
+        },
+        {
+          name: "search_docs",
+          description:
+            "Search through MCP documentation using keywords or phrases. Returns relevant documentation sections with context.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description:
+                  "Search query - keywords, phrases, or specific concepts to find in the documentation",
+              },
+              category: {
+                type: "string",
+                enum: [
+                  "all",
+                  "getting_started",
+                  "concepts",
+                  "development",
+                  "specification",
+                  "tools",
+                  "community",
+                ],
+                description: "Optional: limit search to specific documentation category",
+                default: "all",
+              },
+            },
+            required: ["query"],
+          },
+        },
+        {
+          name: "get_docs_by_category",
+          description:
+            "Get documentation organized by category. Returns structured overview of available documentation in each area.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              category: {
+                type: "string",
+                enum: [
+                  "overview",
+                  "getting_started",
+                  "concepts",
+                  "development",
+                  "specification",
+                  "tools",
+                  "community",
+                ],
+                description: "The documentation category to explore",
+              },
+            },
+            required: ["category"],
+          },
+        },
+      ],
     };
-  } catch (error) {
-    throw new McpError(
-      ErrorCode.InternalError,
-      `Prompt execution failed: ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
-});
+  });
 
-// List available resources
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  return {
-    resources: resources.list()
-  };
-});
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
 
-// Handle resource requests
-server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-  const { uri } = request.params;
-  
-  try {
-    const resource = await resources.read(uri);
+    try {
+      switch (name) {
+        case "mcp_docs_guide":
+          return await mcpDocsGuide.execute(args as any);
+
+        case "search_docs":
+          return await searchDocs.execute(args as any);
+
+        case "get_docs_by_category":
+          return await getDocsByCategory.execute(args as any);
+
+        default:
+          throw new McpError(
+            ErrorCode.MethodNotFound,
+            `Unknown tool: ${name}`
+          );
+      }
+    } catch (error) {
+      if (error instanceof McpError) {
+        throw error;
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  });
+
+  // List available prompts
+  server.setRequestHandler(ListPromptsRequestSchema, async () => {
     return {
-      contents: [resource]
+      prompts: Object.values(prompts).map((prompt: any) => ({
+        name: prompt.name,
+        description: prompt.description,
+        arguments: prompt.arguments || [],
+      })),
     };
-  } catch (error) {
-    throw new McpError(
-      ErrorCode.InvalidRequest,
-      `Resource not found: ${uri}`
-    );
-  }
-});
+  });
+
+  // Handle prompt requests
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    const prompt = (prompts as any)[name];
+    if (!prompt) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Unknown prompt: ${name}`
+      );
+    }
+
+    try {
+      const result = await prompt.handler(args || {});
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: result,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Prompt execution failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  });
+
+  // List available resources
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    return {
+      resources: resources.list(),
+    };
+  });
+
+  // Handle resource requests
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const { uri } = request.params;
+
+    try {
+      const resource = await resources.read(uri);
+      return {
+        contents: [resource],
+      };
+    } catch (error) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Resource not found: ${uri}`
+      );
+    }
+  });
+
+  return server;
+}
+
+export default createServer;
 
 async function main() {
+  const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("MCP Docs Server running on stdio");


### PR DESCRIPTION
## Summary
- add a configurable `createServer` factory and default export so Smithery can start the server module
- keep the CLI flow by instantiating and connecting the server only when the entrypoint is run directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cd51ddc5548325a1623bfa53cd80b7